### PR TITLE
feat: rename oversized to match file property. add oversizeCutoff

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -312,13 +312,22 @@ const config = new class {
         maxChatPurposeLength: 120,
         /**
          * Maximum number of bytes inline image can have (both peerio file and external)
-         * to allow auto-downloading and showing it inline
+         * to allow auto-downloading and showing it inline with "show big files" enabled
+         * or with manual "Display this image"
          * @member {number} chat.inlineImageSizeLimit
          * @memberof config
          * @readonly
          * @public
          */
         inlineImageSizeLimit: 10 * 1024 * 1024,
+        /**
+         * Image bigger than this is not downloaded inline even with manual "Display this image"
+         * @member {number} chat.inlineImageSizeLimitCutoff
+         * @memberof config
+         * @readonly
+         * @public
+         */
+        inlineImageSizeLimitCutoff: 30 * 1024 * 1024,
         allowedInlineContentTypes: {
             'image/jpeg': true,
             'image/bmp': true,

--- a/src/models/chats/message.js
+++ b/src/models/chats/message.js
@@ -16,7 +16,8 @@ const TaskQueue = require('../../helpers/task-queue');
  * @typedef {{
        url : string
        length : number
-       oversized : boolean
+       isOverInlineSizeLimit : boolean
+       isOversizeCutoff : boolean
    }} ExternalImage
  */
 
@@ -314,7 +315,8 @@ class Message extends Keg {
         this.externalImages.push({
             url,
             length,
-            oversized: clientApp.uiUserPrefs.limitInlineImageSize && length > config.chat.inlineImageSizeLimit
+            isOverInlineSizeLimit: clientApp.uiUserPrefs.limitInlineImageSize && length > config.chat.inlineImageSizeLimit,
+            isOversizeCutoff: clientApp.uiUserPrefs.limitInlineImageSize && length > config.chat.inlineImageSizeLimitCutoff
         });
     }
 

--- a/src/models/chats/message.js
+++ b/src/models/chats/message.js
@@ -315,8 +315,9 @@ class Message extends Keg {
         this.externalImages.push({
             url,
             length,
-            isOverInlineSizeLimit: clientApp.uiUserPrefs.limitInlineImageSize && length > config.chat.inlineImageSizeLimit,
-            isOversizeCutoff: clientApp.uiUserPrefs.limitInlineImageSize && length > config.chat.inlineImageSizeLimitCutoff
+            isOverInlineSizeLimit:
+                clientApp.uiUserPrefs.limitInlineImageSize && length > config.chat.inlineImageSizeLimit,
+            isOversizeCutoff: length > config.chat.inlineImageSizeLimitCutoff
         });
     }
 

--- a/src/models/files/file.js
+++ b/src/models/files/file.js
@@ -261,7 +261,7 @@ class File extends Keg {
     }
 
     @computed get isOversizeCutoff() {
-        return clientApp.uiUserPrefs.limitInlineImageSize && this.size > config.chat.inlineImageSizeLimitCutoff;
+        return this.size > config.chat.inlineImageSizeLimitCutoff;
     }
 
     serializeKegPayload() {

--- a/src/models/files/file.js
+++ b/src/models/files/file.js
@@ -409,11 +409,12 @@ class File extends Keg {
         }, 5);
     }
 
-    tryToCacheTemporarily() {
+    tryToCacheTemporarily(force) {
         if (this.tmpCached
             || this.downloading
             || !clientApp.uiUserPrefs.peerioContentEnabled
-            || this.isOverInlineSizeLimit
+            || (!force && this.isOverInlineSizeLimit)
+            || this.isOversizeCutoff
             || this.cachingFailed) return;
 
         this.downloadToTmpCache();

--- a/src/models/files/file.js
+++ b/src/models/files/file.js
@@ -260,6 +260,10 @@ class File extends Keg {
         return clientApp.uiUserPrefs.limitInlineImageSize && this.size > config.chat.inlineImageSizeLimit;
     }
 
+    @computed get isOversizeCutoff() {
+        return clientApp.uiUserPrefs.limitInlineImageSize && this.size > config.chat.inlineImageSizeLimitCutoff;
+    }
+
     serializeKegPayload() {
         return {
             name: this.name,


### PR DESCRIPTION
I have renamed oversized in external images to isOverInlineSizeLimit to match file structure.

I've added:
isOversizeCutoff

to both external image and file. this flag is `true` if we are not do display the image inline under any circumstances. US - https://peerio.tpondemand.com/entity/6873