### PR TITLE
fix: validation returns undefined when disconnected [branch ch8165]

### DIFF
--- a/src/helpers/validation/user-validators.js
+++ b/src/helpers/validation/user-validators.js
@@ -59,8 +59,9 @@ function _callServer(context, name, value) {
                 .then(resp => {
                     resolve(!!resp && resp.valid);
                 })
-                .catch(() => {
-                    resolve(false);
+                .catch((e) => {
+                    if (e.name === 'DisconnectedError') resolve(undefined);
+                    else resolve(false);
                 });
         }, VALIDATION_THROTTLING_PERIOD_MS);
         serverValidationStore.request[key] = { timeout, resolve };

--- a/src/helpers/validation/user-validators.js
+++ b/src/helpers/validation/user-validators.js
@@ -60,7 +60,7 @@ function _callServer(context, name, value) {
                     resolve(!!resp && resp.valid);
                 })
                 .catch((e) => {
-                    if (e.name === 'DisconnectedError') resolve(undefined);
+                    if (e && e.name === 'DisconnectedError') resolve(undefined);
                     else resolve(false);
                 });
         }, VALIDATION_THROTTLING_PERIOD_MS);


### PR DESCRIPTION
#### Relevant info and issue/PR links 
https://app.clubhouse.io/peerio/story/8165/mobile-wrong-validation-state-after-disconnect
https://github.com/PeerioTechnologies/peerio-mobile/pull/222
#### Testing instructions (Mobile)
Disconnect device during "sign up user info" step. Any text inputs which have not been validated should not give any errors. On reconnect, the inputs are re-validated, and any invalid inputs would show errors.

----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
