### PR TITLE
fix: add metaLoaded to ReceivedInvite

### DIFF
--- a/src/models/chats/chat-invite-store.js
+++ b/src/models/chats/chat-invite-store.js
@@ -21,6 +21,7 @@ class ChatHead extends Keg {
 
 class ReceivedInvite {
     @observable declined = false;
+    metaLoaded = true;
     constructor(data) {
         Object.assign(this, data);
     }


### PR DESCRIPTION
#### Relevant info and issue/PR links 
n/a

#### Testing instructions  
room invites not currently working on desktop `dev` due to new `chat.metaLoaded` null check in ChatList. this fixes them.

----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
