### PR TITLE
chore(copy): changed move_to_shared_folder_description copy [branch c…

### DIFF
--- a/src/copy/en.json
+++ b/src/copy/en.json
@@ -246,7 +246,7 @@
   "title_moveFileTo": "Move file or folder to:",
   "dialog_fileMoved": "Your {fileOrFolder} was moved to {folderName}.",
   "title_moveToSharedFolder": "Move to shared folder?",
-  "title_moveToSharedFolderDescription": "You're about to move a file to a shared folder. Anyone that can access this folder will be able to access this file.",
+  "title_moveToSharedFolderDescription": "Items in a shared folder are available to anyone with access to that folder.",
   "title_dontShowMessageAgain": "Don't show this message again",
   "title_sharedFolderCannotBeMoved": "Cannot move shared folder",
   "title_sharedFolderCannotBeMovedDescription": "Shared folders currently cannot be moved into other folders",


### PR DESCRIPTION
…h9387]

#### Relevant info and issue/PR links 
https://app.clubhouse.io/peerio/story/9387/mobile-wrong-copy-for-moving-a-folder-to-a-volume
#### Testing instructions  
N / A

----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
