### PR TITLE
fix: doctor can't be made admin of a room in patient space

### DIFF
--- a/src/models/contacts/contact-store.whitelabel.js
+++ b/src/models/contacts/contact-store.whitelabel.js
@@ -71,15 +71,15 @@ class ContactStoreWhitelabel {
     }
 
     checkMCAdmin(username) {
-        const c = this.getContact(username);
-        if (!c || !c.props.mcrRoles) return null;
-        return c.props.mcrRoles.some(x => x.includes('admin'));
+        const c = this.store.getContact(username);
+        if (!c || !c.mcrRoles) return null;
+        return c.mcrRoles.some(x => x.includes('admin'));
     }
 
     checkMCDoctor(username) {
-        const c = this.getContact(username);
-        if (!c || !c.props.mcrRoles) return null;
-        return c.props.mcrRoles.includes('doctor');
+        const c = this.store.getContact(username);
+        if (!c || !c.mcrRoles) return null;
+        return c.mcrRoles.includes('doctor');
     }
 }
 

--- a/test/e2e/code/steps/medcryptor.js
+++ b/test/e2e/code/steps/medcryptor.js
@@ -146,4 +146,14 @@ Then('I can see their role in the contact details', async function() {
     const contact = await this.contactsHelper.findContact(this.testAccount.username);
     contact.mcrRoles.should.be.an('array');
     contact.mcrRoles[0].should.equal(this.role);
+
+    if (this.role === 'doctor') {
+        ice.contactStore.whitelabel.checkMCAdmin(this.testAccount.username).should.equal(false);
+        ice.contactStore.whitelabel.checkMCDoctor(this.testAccount.username).should.equal(true);
+    }
+
+    if (this.role.startsWith('admin')) {
+        ice.contactStore.whitelabel.checkMCAdmin(this.testAccount.username).should.equal(true);
+        ice.contactStore.whitelabel.checkMCDoctor(this.testAccount.username).should.equal(false);
+    }
 });


### PR DESCRIPTION
#### Relevant info and issue/PR links
https://app.clubhouse.io/peerio/story/7834/desktop-remove-clerk-s-ability-to-promote-doctor-to-admin
 
#### Testing instructions
in MedCryptor, inside any room in a patient space, there should be no menu option in the sidebar for making a doctor account into an admin for the room

----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
