### PR TITLE
fix: recent chat limit weren't working [ch11142]

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -273,7 +273,7 @@ const config = new class {
          * Maximum amount of recent files to maintain in chat object to be able to display the list on UI.
          * @type {number}
          */
-        recentFilesDisplayLimit: 10,
+        recentFilesDisplayLimit: 25,
         /**
          * Maximum number of characters chat name can have.
          * Do not override this in clients, it's supposed to be a system limit.

--- a/src/models/files/file-store.js
+++ b/src/models/files/file-store.js
@@ -263,7 +263,7 @@ class FileStore extends FileStoreBase {
                     return 0;
                 }
             );
-        if (ret.length > config.recentFilesDisplayLimit) ret.length = config.recentFilesDisplayLimit;
+        if (ret.length > config.chat.recentFilesDisplayLimit) ret.length = config.chat.recentFilesDisplayLimit;
         return ret;
     }
 


### PR DESCRIPTION
https://app.clubhouse.io/peerio/story/11142/mobile-recent-files-should-load-a-sane-limit-of-files

fixed.

also changed limit to 25.