### PR TITLE
chore: folder filtering functions

### DIFF
--- a/src/models/files/file-store-base.js
+++ b/src/models/files/file-store-base.js
@@ -71,6 +71,12 @@ class FileStoreBase {
             .filter(f => f.normalizedName.includes(q));
     }
 
+    // Filter folders by a query via function argument instead of using this.searchQuery
+    foldersFiltered = (q) => {
+        return this.folderStore.root.allFolders
+            .filter(f => f.normalizedName.includes(q));
+    }
+
     // Subset of files and folders not currently hidden by any applied filters
     @computed get filesAndFoldersSearchResult() {
         return this.foldersSearchResult.concat(this.filesSearchResult);

--- a/src/models/files/file-store-base.js
+++ b/src/models/files/file-store-base.js
@@ -69,7 +69,6 @@ class FileStoreBase {
         return this.foldersFiltered(this.searchQuery);
     }
 
-    // Filter folders by a query via function argument instead of using this.searchQuery
     foldersFiltered = (query) => {
         const q = query.toUpperCase();
         return this.folderStore.root.allFolders

--- a/src/models/files/file-store-base.js
+++ b/src/models/files/file-store-base.js
@@ -66,13 +66,12 @@ class FileStoreBase {
     // Subset of folders not currently hidden by any applied filters
     @computed get foldersSearchResult() {
         if (!this.searchQuery) return [];
-        const q = this.searchQuery.toUpperCase();
-        return this.folderStore.root.allFolders
-            .filter(f => f.normalizedName.includes(q));
+        return this.foldersFiltered(this.searchQuery);
     }
 
     // Filter folders by a query via function argument instead of using this.searchQuery
-    foldersFiltered = (q) => {
+    foldersFiltered = (query) => {
+        const q = query.toUpperCase();
         return this.folderStore.root.allFolders
             .filter(f => f.normalizedName.includes(q));
     }


### PR DESCRIPTION
#### Relevant info and issue/PR links 
https://github.com/PeerioTechnologies/peerio-desktop/compare/fix-files-search?expand=1

#### Testing instructions  
Desktop fix (see PR) requires the ability to filter folders by a query passed through argument, rather than through global `fileStore.searchQuery`

----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
