### PR TITLE
fix(chat): don't report initial page load until we added messages

### DIFF
--- a/src/models/chats/chat.message-handler.js
+++ b/src/models/chats/chat.message-handler.js
@@ -200,14 +200,15 @@ class ChatMessageHandler {
         }, false))
             .then(action(resp => {
                 this.chat.canGoUp = resp.hasMore;
-                this.chat.initialPageLoaded = true;
-                this.chat.loadingInitialPage = false;
                 this.chat._cancelTopPageLoad = false;
                 this.chat._cancelBottomPageLoad = false;
                 this.setDownloadedUpdateId(resp.kegs);
                 if (!this.chat.canGoDown) this.markAllAsSeen();
                 console.log(`got initial ${resp.kegs.length} for this.chat`, this.chat.id);
-                return this.chat.addMessages(resp.kegs);
+                return this.chat.addMessages(resp.kegs).finally(() => {
+                    this.chat.loadingInitialPage = false;
+                    this.chat.initialPageLoaded = true;
+                });
             }))
             .catch((err) => {
                 if (err && err.code === errorCodes.accessForbidden) {


### PR DESCRIPTION
This makes initial chat load indicator spin until we added messages and
avoids many renders of intermediate state while messages are being added
on desktop.

#### Relevant info and issue/PR links 
 
#### Testing instructions  

Load chats, see if they load 🤷‍♂️ 

----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
