### PR TITLE
fix: save settings in a concurrent-safe way [ch12811]

### DIFF
--- a/src/models/user/user.profile.js
+++ b/src/models/user/user.profile.js
@@ -38,7 +38,11 @@ module.exports = function mixUserProfileModule() {
             when(
                 () => !settings.loading,
                 () => {
-                    if (updateFunction) updateFunction(settings);
+                    if (!updateFunction)
+                        throw new Error(
+                            'Must provide update function to saveSettings'
+                        );
+                    updateFunction(settings);
                     resolve(
                         settings.saveToServer().tapCatch(err => {
                             console.error(err);

--- a/src/models/user/user.profile.js
+++ b/src/models/user/user.profile.js
@@ -39,9 +39,7 @@ module.exports = function mixUserProfileModule() {
                 () => !settings.loading,
                 () => {
                     if (!updateFunction)
-                        throw new Error(
-                            'Must provide update function to saveSettings'
-                        );
+                        throw new Error('Must provide update function to saveSettings');
                     updateFunction(settings);
                     resolve(
                         settings.saveToServer().tapCatch(err => {

--- a/src/models/user/user.profile.js
+++ b/src/models/user/user.profile.js
@@ -32,11 +32,22 @@ module.exports = function mixUserProfileModule() {
         loadSimpleKeg(this.settings);
     };
 
-    this.saveSettings = () => {
-        return this.settings.saveToServer().tapCatch(err => {
-            console.error(err);
-            warnings.add('error_saveSettings');
-        });
+    this.saveSettings = updateFunction => {
+        const { settings } = this;
+        return new Promise(resolve =>
+            when(
+                () => !settings.loading,
+                () => {
+                    if (updateFunction) updateFunction(settings);
+                    resolve(
+                        settings.saveToServer().tapCatch(err => {
+                            console.error(err);
+                            warnings.add('error_saveSettings');
+                        })
+                    );
+                }
+            )
+        );
     };
 
     this.loadProfile = () => {

--- a/test/e2e/code/steps/account.js
+++ b/test/e2e/code/steps/account.js
@@ -36,15 +36,15 @@ Then('I should have default account settings', async function() {
 });
 
 When('I change my account settings', async function() {
-    const { settings } = ice.User.current;
-    settings.contactNotifications = true;
-    settings.contactRequestNotifications = true;
-    settings.messageNotifications = false;
-    settings.errorTracking = true;
-    settings.dataCollection = true;
-    settings.subscribeToPromoEmails = true;
-    await ice.User.current.saveSettings();
-    return this.waitFor(() => settings.version === 2);
+    await ice.User.current.saveSettings(settings => {
+        settings.contactNotifications = true;
+        settings.contactRequestNotifications = true;
+        settings.messageNotifications = false;
+        settings.errorTracking = true;
+        settings.dataCollection = true;
+        settings.subscribeToPromoEmails = true;
+    });
+    return this.waitFor(() => ice.User.current.settings.version === 2);
 });
 
 Then('my account settings are changed', async function() {


### PR DESCRIPTION
#### Relevant info and issue/PR links 
 
https://app.clubhouse.io/peerio/story/12811/sdk-make-saving-settings-concurrent-safe

because settings keg contain multiple fields which are usually assigned independently, to prevent overwriting values with the new ones from server an updater callback is introduced.

@anri-asaturov it's up to your discretion if we want to get rid of default behaviour (just save all the settings object without updater function) completely, or no.

this is a desktop branch for testing:
https://github.com/PeerioTechnologies/peerio-desktop/tree/feat-settings-concurrent-updates

contains only 1 setting to test - promo emails.