### PR TITLE
fix: hack for progress downloads in case onprogress does not work [ch…

### DIFF
--- a/src/models/files/file-downloader.js
+++ b/src/models/files/file-downloader.js
@@ -218,6 +218,10 @@ class FileDownloader extends FileProcessor {
                 return true;
             };
 
+            // HACK: if there was no progress event fired
+            // calculate the file progress from completion handler
+            let progressEventFired = false;
+
             xhr.onreadystatechange = function() {
                 if (this.readyState === LOADING) {
                     // Download started, maybe start
@@ -238,6 +242,9 @@ class FileDownloader extends FileProcessor {
                     (this.status === 200 || this.status === 206) &&
                     this.response.byteLength === expectedSize
                 ) {
+                    if (!progressEventFired) {
+                        self.file.progress += expectedSize;
+                    }
                     resolve(this.response); // success
                     return;
                 }
@@ -264,6 +271,7 @@ class FileDownloader extends FileProcessor {
             };
 
             xhr.onprogress = function(event) {
+                progressEventFired = true;
                 if (p.isRejected()) return;
                 if (event.loaded > lastLoaded) {
                     self.file.progress += event.loaded - lastLoaded;


### PR DESCRIPTION
…12982]

#### Relevant info and issue/PR links 

For mobile on the staging server onprogress event does not fire for some reason yet not clear. On prod it works fine and on desktop it works fine.

My assumption is that something changed with CSP on the file server.

https://app.clubhouse.io/peerio/story/12982/mobile-can-t-download-large-file
 
#### Testing instructions  

mobile and desktop should display adequate download progress when downloading in-chat and in-files.


----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
