### PR TITLE
chore: copy string for 500 mb bonus [ch12634]

### DIFF
--- a/src/copy/en.json
+++ b/src/copy/en.json
@@ -854,7 +854,7 @@
   "title_onboardingAccountKey": "Save your Account Key PDF document",
   "title_onboardingAccountKeyContent": "Unlock 100 MB and ensure you can access your account at any time.",
   "title_onboardingConfirmEmail": "Confirm your email",
-  "title_onboardingConfirmEmailContent": "Unlock 100 MB storage and unlock additional functionality.",
+  "title_onboardingConfirmEmailContent": "Unlock 500 MB storage and unlock additional functionality.",
   "title_onboardingCreateARoom": "Create a Room",
   "title_onboardingCreateARoomContent": "Unlock 100 MB for opening a Room.",
   "title_onboardingInvitePeople": "Invite friends to join Peerio ({current}/{max})",


### PR DESCRIPTION
#### Relevant info and issue/PR links 
 
https://app.clubhouse.io/peerio/story/12634/update-bonus-for-confirming-email-to-500mb

#### Testing instructions  

Confirm email bonus description (on zero state screen or on bonus summary screen) should mention 500 Mb increase instead of 100 Mb.

----
### Repository owner

Wait for server task to be merged https://github.com/PeerioTechnologies/peerio-server/pull/726 before merging SDK.

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
