### PR TITLE
fix: make mixin not create enumerable properties on the prototype [ch…

### DIFF
--- a/src/models/files/file.ts
+++ b/src/models/files/file.ts
@@ -758,7 +758,7 @@ function mixInProperly(proto, source) {
         Object.defineProperty(proto, key, {
             value: source[key],
             enumerable: false,
-            writeable: true
+            writable: true
         });
     }
 }

--- a/src/models/files/file.ts
+++ b/src/models/files/file.ts
@@ -752,5 +752,16 @@ export default class File extends Keg<IFilePayload, IFileProps> {
         );
     }
 }
-Object.assign(File.prototype, uploadModule);
-Object.assign(File.prototype, downloadModule);
+
+function mixInProperly(proto, source) {
+    for (const key in source) {
+        Object.defineProperty(proto, key, {
+            value: source[key],
+            enumerable: false,
+            writeable: true
+        });
+    }
+}
+
+mixInProperly(File.prototype, uploadModule);
+mixInProperly(File.prototype, downloadModule);


### PR DESCRIPTION
#### Relevant info and issue/PR links 

https://app.clubhouse.io/peerio/story/14573/sdk-object-assign-crashes-when-operating-with-objects-of-file-prototype
 
#### Testing instructions  

Opening a chat with legacy files shouldn't produce errors in the console of the type:

```
TypeError: One of the sources for assign has an enumerable key on the prototype chain. Are you trying to assign a prototype property? We don't allow it...

```
