### PR TITLE
feat: add disable onboarding emails flag to user settings

### DIFF
--- a/src/models/user/settings.ts
+++ b/src/models/user/settings.ts
@@ -8,6 +8,7 @@ interface ISettingsPayload {
     messageNotifications: boolean;
     dataCollectionOptIn: boolean;
     subscribeToPromoEmails: boolean;
+    disableOnboardingEmails: boolean;
 }
 interface ISettingsProps {}
 
@@ -28,6 +29,7 @@ export default class Settings extends Keg<ISettingsPayload, ISettingsProps> {
     @observable messageNotifications = false;
     @observable dataCollection = false;
     @observable subscribeToPromoEmails = false;
+    @observable disableOnboardingEmails = false;
 
     @observable loaded = false;
 
@@ -37,7 +39,8 @@ export default class Settings extends Keg<ISettingsPayload, ISettingsProps> {
             contactRequestNotifications: this.contactRequestNotifications,
             messageNotifications: this.messageNotifications,
             dataCollectionOptIn: this.dataCollection,
-            subscribeToPromoEmails: this.subscribeToPromoEmails
+            subscribeToPromoEmails: this.subscribeToPromoEmails,
+            disableOnboardingEmails: this.disableOnboardingEmails
         };
     }
 
@@ -47,6 +50,7 @@ export default class Settings extends Keg<ISettingsPayload, ISettingsProps> {
         this.messageNotifications = data.messageNotifications;
         this.dataCollection = data.dataCollectionOptIn;
         this.subscribeToPromoEmails = data.subscribeToPromoEmails;
+        this.disableOnboardingEmails = data.disableOnboardingEmails;
         this.loaded = true;
     }
 }


### PR DESCRIPTION
#### Relevant info and issue/PR links 

https://app.clubhouse.io/peerio/story/15032/mobile-default-behaviour-for-subscribetopromoemails-flag#activity=15038 

#### Testing instructions  

When server is deployed to staging, the settings collection should now have `disableOnboardingEmails`.

Should be able to be used like this:

![image](https://user-images.githubusercontent.com/750359/46959593-6a1a0100-d06a-11e8-9cea-e2550473faed.png)


----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
