### PR TITLE
chore(copy): remove unused title_errorTrackingMessage

### DIFF
--- a/src/copy/en.json
+++ b/src/copy/en.json
@@ -579,7 +579,6 @@
   "button_notNow": "Not now",
   "title_dataPreferences": "Data",
   "title_dataDetail": "Help us improve your experience and fix bugs faster by sharing data with us automatically",
-  "title_errorTrackingMessage": "Share crash & error reports",
   "title_dataCollectionMessage": "Share anonymous usage data",
   "button_accountDelete": "Delete account",
   "title_accountDelete": "Do you want to delete your account?",


### PR DESCRIPTION
#### Relevant info and issue/PR links 
https://app.clubhouse.io/peerio/story/14375/mobile-include-usage-statistics-in-error-reporting-setting
https://github.com/PeerioTechnologies/peerio-mobile/pull/349
This copy is no longer being used on mobile. I verified with Lucas that this copy isn't being used on Desktop either anymore.
#### Testing instructions  
N / A

----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
