### PR TITLE
chore: copy for tray icon notifications on Windows

### DIFF
--- a/src/copy/en.json
+++ b/src/copy/en.json
@@ -633,6 +633,8 @@
   "notification_roomInviteBody": "{name} has invited you to the room #{room}",
   "notification_inviteAcceptedTitle": "Invitation accepted",
   "notification_inviteAcceptedBody": "Your contact {firstName} (@{username}) has joined Peerio",
+  "notification_peerioInTrayTitle": "Peerio is still running",
+  "notification_peerioInTrayBody": "You will continue to receive messages and notifications. To quit, right-click on Peerio icon in taskbar notification area and select \"Quit Peerio\".",
   "title_contacts": "Contacts",
   "title_contactGroups": "Groups",
   "title_contactsAllowAccess": "Please allow accessing contacts",


### PR DESCRIPTION
#### Relevant info and issue/PR links 

https://app.clubhouse.io/peerio/story/15728/desktop-windows-copy-for-notification-when-minimizing-to-tray-for-the-first-time

https://github.com/PeerioTechnologies/peerio-desktop/pull/465 

#### Testing instructions  


----
### Repository owner

- [ ] Was tested and can be merged.
- [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)