### PR TITLE
chore: file search result order new-to-old

### DIFF
--- a/src/models/files/file-store-base.ts
+++ b/src/models/files/file-store-base.ts
@@ -100,12 +100,17 @@ class FileStoreBase {
         return ret;
     }
 
+    @computed
+    get allFilesSortedByDate() {
+        return this.allFiles.sort(FileFolder.kegUpdatedComparer);
+    }
+
     // Subset of files not currently hidden by any applied filters
     @computed
     get filesSearchResult() {
         if (!this.searchQuery) return [];
         const q = this.searchQuery.toUpperCase();
-        return this.allFiles.filter(f => f.normalizedName.includes(q));
+        return this.allFilesSortedByDate.filter(f => f.normalizedName.includes(q));
     }
 
     // Subset of folders not currently hidden by any applied filters


### PR DESCRIPTION
#### Relevant info and issue/PR links
https://app.clubhouse.io/peerio/story/12463/desktop-incorrect-sort-for-search-results
https://github.com/PeerioTechnologies/peerio-desktop/pull/521

#### Testing instructions
File search results should now return newest-to-oldest. Bug was noticed on desktop but may be on mobile too.

---

### Repository owner

-   [ ] Was tested and can be merged.
-   [ ] PR name follows conventional changelog format.

[PR guideline](https://github.com/PeerioTechnologies/peerio-icebear/blob/dev/docs/CONTRIBUTING.md)
